### PR TITLE
Finish handling of uploaded captions in rec processing scripts

### DIFF
--- a/record-and-playback/core/.gitignore
+++ b/record-and-playback/core/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+vendor

--- a/record-and-playback/core/Gemfile
+++ b/record-and-playback/core/Gemfile
@@ -36,5 +36,5 @@ gem "rubyzip"
 gem "trollop", "2.1.3"
 
 group :test, optional: true do
-  gem "rubocop", "~> 0.71.0"
+  gem "rubocop", "~> 0.72.0"
 end

--- a/record-and-playback/core/Gemfile.lock
+++ b/record-and-playback/core/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
     fastimage (2.1.5)
     ffi (1.11.1)
     fnv (0.2.0)
-    jaro_winkler (1.5.2)
+    jaro_winkler (1.5.3)
     java_properties (0.0.4)
     journald-logger (2.0.4)
       journald-native (~> 1.0)
@@ -29,7 +29,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.2)
-    rubocop (0.71.0)
+    rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -58,7 +58,7 @@ DEPENDENCIES
   open4
   rb-inotify
   redis
-  rubocop (~> 0.71.0)
+  rubocop (~> 0.72.0)
   rubyzip
   trollop (= 2.1.3)
 

--- a/record-and-playback/core/scripts/rap-process-worker.rb
+++ b/record-and-playback/core/scripts/rap-process-worker.rb
@@ -47,9 +47,7 @@ def process_archived_meetings(recording_dir)
 
     # Generate captions
     ret = BigBlueButton.exec_ret('ruby', 'utils/captions.rb', '-m', meeting_id)
-    if ret != 0
-      BigBlueButton.logger.warn("Failed to generate caption files #{ret}")
-    end
+    BigBlueButton.logger.warn("Failed to generate caption files #{ret}") if ret != 0
 
     # Iterate over the list of recording processing scripts to find available
     # types. For now, we look for the ".rb" extension - TODO other scripting

--- a/record-and-playback/core/scripts/utils/gen_webvtt
+++ b/record-and-playback/core/scripts/utils/gen_webvtt
@@ -307,8 +307,10 @@ class Caption:
     def caption_desc(self):
         locale = Locale(self.locale)
         return {
-                "locale": self.locale,
-                "localeName": locale.getDisplayName(locale)
+                "kind": "captions",
+                "label": locale.getDisplayName(locale),
+                "lang": self.locale,
+                "source": "live"
                 }
 
 
@@ -410,15 +412,16 @@ if __name__ == "__main__":
 
     logger.info("Generating caption data from recording events")
     captions = Caption.from_events(events)
-    for locale, caption in captions.items():
-        filename = os.path.join(outputdir, "caption_{}.vtt".format(locale))
-        logger.info("Writing captions for locale %s to %s", locale, filename)
+    caption_descs = []
+    for caption in captions.values():
+        desc = caption.caption_desc()
+        caption_descs.append(desc)
+        filename = os.path.join(outputdir, "{}_{}.vtt".format(desc['kind'], desc['lang']))
+        logger.info("Writing %s for locale %s to %s", desc['kind'], desc['lang'], filename)
         with open(filename, "wb") as f:
             caption.write_webvtt(f)
 
     filename = os.path.join(outputdir, "captions.json")
     logger.info("Writing captions index file to %s", filename)
-
-    caption_descs = [ caption.caption_desc() for caption in captions.values() ]
     with open(filename, "w") as f:
         json.dump(caption_descs, f)

--- a/record-and-playback/presentation/playback/presentation/2.0/playback.js
+++ b/record-and-playback/presentation/playback/presentation/2.0/playback.js
@@ -306,11 +306,20 @@ function loadVideo() {
     logger.info("==Processing captions.json");
     var captions = JSON.parse(response.responseText);
     for (var i = 0; i < captions.length; i++) {
+      var caption = captions[i];
+      var filename;
+      if (caption['kind']) {
+        filename = caption['kind'] + '_' + caption['locale'] + '.vtt';
+      } else {
+        // Backwards compat for old style captions index without "kind"
+        caption['kind'] = 'captions';
+        filename = 'caption_' + caption['locale'] + '.vtt';
+      }
       var track = document.createElement("track");
-      track.setAttribute('kind', 'captions');
-      track.setAttribute('label', captions[i]['localeName']);
-      track.setAttribute('srclang', captions[i]['locale']);
-      track.setAttribute('src', url + '/caption_' + captions[i]['locale'] + '.vtt');
+      track.setAttribute('kind', caption['kind']);
+      track.setAttribute('label', caption['localeName']);
+      track.setAttribute('srclang', caption['locale']);
+      track.setAttribute('src', url + '/' + filename);
       video.appendChild(track);
     }
     document.dispatchEvent(new CustomEvent('media-ready', {'detail': 'captions'}));

--- a/record-and-playback/presentation/scripts/caption/presentation
+++ b/record-and-playback/presentation/scripts/caption/presentation
@@ -50,15 +50,16 @@ end
 logger = Journald::Logger.new('caption/presentation')
 logger.tag(record_id: recording_id)
 
-captions_dir = props['captions_dir']
-publish_dir = presentation_props['publish_dir']
-
-unless captions_dir
+unless props['captions_dir']
   logger.error('captions_dir was not defined in bigbluebutton.yml')
   exit(1)
 end
 
-unless File.directory?(File.join(publish_dir, recording_id))
+recording_dir = props['recording_dir']
+captions_dir = File.join(props['captions_dir'], recording_id)
+publish_dir = File.join(presentation_props['publish_dir'], recording_id)
+
+unless File.directory?(publish_dir)
   logger.error('Published recording directory for this recording does not exist')
   exit(0)
 end
@@ -67,14 +68,12 @@ end
 
 begin
   logger.info('Loading recording playback captions list')
-  playback_captions_path = File.join(publish_dir, recording_id, 'captions.json')
-  playback_captions = File.open(playback_captions_path) do |json|
-    JSON.parse(json.read)
-  end
+  playback_captions_path = File.join(publish_dir, 'captions.json')
+  playback_captions = JSON.parse(IO.read(playback_captions_path))
 rescue Errno::ENOENT
   logger.info("Playback doesn't have a captions.json - old playback format version?")
   logger.info('Triggering recording reprocessing.')
-  archive_done_file = ''
+  archive_done_file = "#{recording_dir}/status/archived/#{recording_id}.done"
   File.open(archive_done_file, 'w') do |archive_done|
     archive_done.write('Reprocessing for captions')
   end
@@ -85,12 +84,13 @@ end
 # Captions index file
 begin
   logger.info('Loading captions index file')
-  captions_path = File.join(captions_dir, recording_id, 'captions.json')
+  captions_path = File.join(captions_dir, 'captions.json')
   captions = File.open(captions_path) do |json|
     JSON.parse(json.read)
   end
 rescue Errno::ENOENT
-  captions = []
+  logger.info('No captions index file found, nothing to do.')
+  exit(0)
 end
 
 # Copy the new caption files over the existing ones in the playback
@@ -100,27 +100,13 @@ captions.each do |caption|
   lang = caption['lang']
   label = caption['label']
 
-  # TODO: the presentation playback format needs to be updated to support
-  # kind != captions
-  next unless kind == 'captions'
-
   logger.info("Copying file for kind=#{kind} lang=#{lang}")
-  dest_kind = case kind
-              when 'captions' then 'caption'
-              else kind
-              end
-
-  FileUtils.cp(
-    File.join(captions_dir, recording_id, "#{kind}_#{lang}.vtt"),
-    File.join(publish_dir, recording_id, "#{dest_kind}_#{lang}.vtt")
-  )
+  FileUtils.cp(File.join(captions_dir, "#{kind}_#{lang}.vtt"), publish_dir)
 
   # Remove any existing matching tracks from the playback captions list...
   playback_captions.reject! do |playback_caption|
-    playback_caption['locale'] == lang && (
-      playback_caption['kind'] == kind ||
-      (playback_caption['kind'].nil? && kind == 'captions')
-    )
+    playback_caption['locale'] == lang &&
+      (playback_caption['kind'] == kind || (playback_caption['kind'].nil? && kind == 'captions'))
   end
   # ...and add the new one.
   playback_captions << {
@@ -130,11 +116,7 @@ captions.each do |caption|
   }
 end
 
-# Save the updated playback captions list
-
 logger.info('Saving updated playback captions list')
 # Sort the list by label so the selection menu looks nice
 playback_captions.sort { |a, b| a['localeName'] <=> b['localeName'] }
-File.open(playback_captions_path, 'w') do |json|
-  json.write(JSON.pretty_generate(playback_captions))
-end
+IO.write(playback_captions_path, JSON.pretty_generate(playback_captions))

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1228,7 +1228,7 @@ begin
         if File.exist?("#{$process_dir}/captions.json")
           BigBlueButton.logger.info("Copying caption files")
           FileUtils.cp("#{$process_dir}/captions.json", package_dir)
-          Dir.glob("#{$process_dir}/caption_*.vtt").each do |caption|
+          Dir.glob("#{$process_dir}/*.vtt").each do |caption|
             BigBlueButton.logger.debug(caption)
             FileUtils.cp(caption, package_dir)
           end


### PR DESCRIPTION
* Presentation format playback scripts now support text tracks with
  kind != "captions", including backwards compat for existing recordings that
  don't specify track kind
* Presentation processing script no longer duplicates the caption processing
  done by the captions.rb script (which is run by rap-process-worker.rb before
  any of the format-specific scripts). It now just copies the already-processed
  captions into the playback.
* gen_webvtt script output format has changed to match the text tracks api
  spec. This script is now only called by utils/captions.rb.